### PR TITLE
feat: Add Jarvis 2.0 GoRouter template support

### DIFF
--- a/bin/add_module_action.dart
+++ b/bin/add_module_action.dart
@@ -93,12 +93,23 @@ Future<void> addModuleAction() async {
   }
 
   String moduleTemplateUrl;
+  bool isGoRouter = false;
 
   if (isJarvis2Project) {
-    moduleTemplateUrl = AppConstants.kRemoteJarvis2ModuleTemplatesLink;
-    logger.info('✅ Detected Jarvis 2.0 project, using Jarvis 2.0 module template');
+    // Detect router type for Jarvis 2.0 projects
+    final File navigationPubspecFile = File('${path}navigation/pubspec.yaml');
+    if (navigationPubspecFile.existsSync()) {
+      final String navPubspecContent = navigationPubspecFile.readAsStringSync();
+      isGoRouter = navPubspecContent.contains('go_router:');
+    }
+
+    moduleTemplateUrl = isGoRouter
+        ? AppConstants.kRemoteJarvis2GoRouterModuleTemplatesLink
+        : AppConstants.kRemoteJarvis2ModuleTemplatesLink;
+
+    logger.info('✅ Detected Jarvis 2.0 project (${isGoRouter ? 'GoRouter' : 'AutoRoute'}), using Jarvis 2.0 module template');
   } else {
-    final bool isGoRouter = logger.chooseOne(
+    isGoRouter = logger.chooseOne(
       AppConstants.kGoRouter,
       choices: <String?>[
         AppConstants.kYes,

--- a/bin/create_action.dart
+++ b/bin/create_action.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:jarvis/src/constants/app_constants.dart';
+import 'package:jarvis/src/enums/template_type.dart';
 import 'package:jarvis/src/services/app_add_util.dart';
 import 'package:jarvis/src/services/directory_service.dart';
 import 'package:jarvis/src/services/input_service.dart';
@@ -94,24 +95,14 @@ Future<void> createAction() async {
 
   final String? templateChoice = logger.chooseOne(
         'Choose template:',
-        choices: <String>[
-          '1) Standard (AutoRoute)',
-          '2) Standard (GoRouter)',
-          '3) Jarvis 2.0 (AutoRoute + Clean Architecture + Workspace)',
-        ],
+        choices: TemplateType.displayNames,
       ) ??
-      '1) Standard (AutoRoute)';
+      TemplateType.standardAutoRoute.displayName;
 
-  String templateUrl;
-  if (templateChoice.startsWith('1)')) {
-    templateUrl = AppConstants.kRemoteTemplatesLink;
-  } else if (templateChoice.startsWith('2)')) {
-    templateUrl = AppConstants.kRemoteGoTemplatesLink;
-  } else {
-    templateUrl = AppConstants.kRemoteJarvis2AutoRouteTemplatesLink;
-  }
+  final TemplateType selectedTemplate = TemplateType.fromDisplayName(templateChoice);
+  final String templateUrl = selectedTemplate.templateUrl;
 
-  logger.info('Selected template: $templateChoice');
+  logger.info('Selected template: ${selectedTemplate.displayName}');
 
   if (!templatesDirectory.existsSync()) {
     await DirectoryService.cloneRepository(

--- a/lib/src/constants/app_constants.dart
+++ b/lib/src/constants/app_constants.dart
@@ -104,6 +104,10 @@ class AppConstants {
       'https://github.com/youRaSoftware/jarvis_2.0_autoroute';
   static const String kRemoteJarvis2ModuleTemplatesLink =
       'https://github.com/youRaSoftware/jarvis_2.0_module';
+  static const String kRemoteJarvis2GoRouterTemplatesLink =
+      'https://github.com/youRaSoftware/jarvis_2.0_gorouter';
+  static const String kRemoteJarvis2GoRouterModuleTemplatesLink =
+      'https://github.com/youRaSoftware/jarvis_2.0_gorouter_module';
 
   static const String kLogo = '''
     ░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓███████▓▒░ 

--- a/lib/src/enums/template_type.dart
+++ b/lib/src/enums/template_type.dart
@@ -1,0 +1,57 @@
+import 'package:jarvis/src/constants/app_constants.dart';
+
+enum TemplateType {
+  standardAutoRoute(
+    id: 1,
+    displayName: '1) Standard (AutoRoute)',
+    templateUrl: AppConstants.kRemoteTemplatesLink,
+    moduleUrl: AppConstants.kRemoteModuleTemplatesLink,
+    isGoRouter: false,
+  ),
+  standardGoRouter(
+    id: 2,
+    displayName: '2) Standard (GoRouter)',
+    templateUrl: AppConstants.kRemoteGoTemplatesLink,
+    moduleUrl: AppConstants.kRemoteGoModuleTemplatesLink,
+    isGoRouter: true,
+  ),
+  jarvis2AutoRoute(
+    id: 3,
+    displayName: '3) Jarvis 2.0 (AutoRoute + Clean Architecture + Workspace)',
+    templateUrl: AppConstants.kRemoteJarvis2AutoRouteTemplatesLink,
+    moduleUrl: AppConstants.kRemoteJarvis2ModuleTemplatesLink,
+    isGoRouter: false,
+  ),
+  jarvis2GoRouter(
+    id: 4,
+    displayName: '4) Jarvis 2.0 (GoRouter + Clean Architecture + Workspace)',
+    templateUrl: AppConstants.kRemoteJarvis2GoRouterTemplatesLink,
+    moduleUrl: AppConstants.kRemoteJarvis2GoRouterModuleTemplatesLink,
+    isGoRouter: true,
+  );
+
+  const TemplateType({
+    required this.id,
+    required this.displayName,
+    required this.templateUrl,
+    required this.moduleUrl,
+    required this.isGoRouter,
+  });
+
+  final int id;
+  final String displayName;
+  final String templateUrl;
+  final String moduleUrl;
+  final bool isGoRouter;
+
+  static TemplateType fromDisplayName(String displayName) {
+    return TemplateType.values.firstWhere(
+      (TemplateType type) => type.displayName == displayName,
+      orElse: () => TemplateType.standardAutoRoute,
+    );
+  }
+
+  static List<String> get displayNames {
+    return TemplateType.values.map((TemplateType type) => type.displayName).toList();
+  }
+}


### PR DESCRIPTION
- Add TemplateType enum for type-safe template selection
- Add Jarvis 2.0 GoRouter template and module template URLs
- Update create_action.dart to use enum-based template selection
- Update add_module_action.dart to auto-detect GoRouter in Jarvis 2.0 projects
- Support both AutoRoute and GoRouter variants of Jarvis 2.0